### PR TITLE
Fix member role color in userinfo command

### DIFF
--- a/src/commands/context/userinfo.js
+++ b/src/commands/context/userinfo.js
@@ -66,7 +66,7 @@ module.exports = {
           ].join("\n"),
         },
       )
-      .setColor(member.roles.color.hexColor || client.utils.getRandomColor());
+      .setColor(member.roles.color?.hexColor || client.utils.getRandomColor());
 
     interaction.followUp({
       embeds: [embed],


### PR DESCRIPTION
This pull request fixes the issue with the member role color in the userinfo command. Previously, the code was throwing an error when trying to access the `hexColor` property of the `color` object. This pull request updates the code to use optional chaining (`?.`) to safely access the `hexColor` property. Now, the userinfo command will display the correct member role color without any errors.